### PR TITLE
Bugfixes for config values

### DIFF
--- a/rex_xai/config.py
+++ b/rex_xai/config.py
@@ -49,7 +49,7 @@ class Args:
         # onnx processing
         self.means = None
         self.stds = None
-        self.norm: Optional[float] = None
+        self.norm: Optional[float] = 255.0
         self.binary_threshold = None
         # verbosity
         self.verbosity = 0

--- a/rex_xai/config.py
+++ b/rex_xai/config.py
@@ -130,11 +130,14 @@ class CausalArgs(Args):
         self.distribution_args: Optional[List] = None
         self.blend = 0.0
         self.weighted: bool = False
-        self.iters = 30
+        self.iters = 20
         self.concentrate = False
         # queue management
         self.queue_len = 1
         self.queue_style = Queue.Area
+
+        if self.min_box_size is not None:
+            self.chunk_size = self.min_box_size
 
     def __repr__(self) -> str:
         return (

--- a/rex_xai/explanation.py
+++ b/rex_xai/explanation.py
@@ -49,7 +49,7 @@ def try_preprocess(args: CausalArgs, model_shape: Tuple[int], device: str):
         # if not args.processed:
         data = Data(Image.open(args.path), model_shape, device)
         # data = Data(Image.open(args.path).convert("RGB"), model_shape, device)
-        data.generic_image_preprocess(means=args.means, stds=args.stds)
+        data.generic_image_preprocess(means=args.means, stds=args.stds, norm=args.norm)
 
     # a compressed numpy array file
     elif ext in ".npy":

--- a/rex_xai/input_data.py
+++ b/rex_xai/input_data.py
@@ -96,7 +96,7 @@ class Data:
 
         normed_data = self.data
         if norm is not None:
-            normed_data /= 255.0
+            normed_data /= norm
 
         if self.model_order == "first" and self.model_channels == 3:
             if means is not None:
@@ -146,7 +146,7 @@ class Data:
         means=None,
         stds=None,
         astype="float32",
-        norm: Optional[float] = 1.0,
+        norm: Optional[float] = 255.0,
     ):
         self.load_data(astype=astype)
 


### PR DESCRIPTION
* set the default value of `causal.iters` to be 20 (instead of 30)
* set the default value of `explanation.chunk_size` to be the value of `causal.min_box_size` (if this is not None), instead of being 25
* set the default value of `onnx.norm` to be 255.0
* ensure config value of `onnx.norm` is correctly passed through to `generic_image_preprocess()`
* the `norm` parameter is not used at all for tabular/spectral data so I didn't bother adding a warning here