### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/build-and-test-python-package.yml
+++ b/.github/workflows/build-and-test-python-package.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.12"]
 
     permissions:
       pull-requests: write

--- a/.github/workflows/build-and-test-python-package.yml
+++ b/.github/workflows/build-and-test-python-package.yml
@@ -1,7 +1,7 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# This workflow will install ReX and run tests, using the highest and lowest Python versions we support
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Run tests and checks
+name: Build and run tests 
 
 on: pull_request
 
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.13"]
 
     permissions:
       pull-requests: write
@@ -29,12 +29,6 @@ jobs:
     - run: poetry install --with dev
     - run: echo "$(poetry env info --path)/bin" >> $GITHUB_PATH
 
-    - name: Lint with Ruff
-      run: |
-        ruff check --output-format=github .
-    - name: Install ReX
-      run: |
-        poetry install 
     - name: Test with pytest
       run: |
         pytest --junitxml=pytest.xml --cov-report=xml:coverage.xml --cov=rex_xai tests/
@@ -43,11 +37,5 @@ jobs:
       if: ${{ !github.event.pull_request.head.repo.fork }}
       with:
         pytest-xml-coverage-path: ./coverage.xml
-    - name: Type checking with Pyright
-      uses: YajJackson/simple-pyright-action@v1.0.0
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        include-base-comparison: true
-        fail-on-issue-increase: true
-        include-file-comments: false
+
 

--- a/.github/workflows/linting-and-type-check.yml
+++ b/.github/workflows/linting-and-type-check.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.12"]
 
     permissions:
       pull-requests: write

--- a/.github/workflows/linting-and-type-check.yml
+++ b/.github/workflows/linting-and-type-check.yml
@@ -1,0 +1,43 @@
+# This workflow will install ReX and carry out linting and type checking 
+
+name: Linting and type checking
+
+on: pull_request
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.13"]
+
+    permissions:
+      pull-requests: write
+    
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install poetry
+      run: pipx install poetry
+
+    - name: Set up Python, install and cache dependencies
+      uses: actions/setup-python@v5
+      with:
+          python-version: ${{matrix.python-version}}
+          cache: poetry
+    - run: poetry install --with dev
+    - run: echo "$(poetry env info --path)/bin" >> $GITHUB_PATH
+
+    - name: Lint with Ruff
+      run: |
+        ruff check --output-format=github .
+
+    - name: Type checking with Pyright
+      uses: YajJackson/simple-pyright-action@v1.0.0
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        include-base-comparison: true
+        fail-on-issue-increase: true
+        include-file-comments: false
+


### PR DESCRIPTION
- separate linting and type checking from building and testing 
- run building and testing on only the lowest and highest python versions we support
- only run linting and type checking on one python version