### PR TITLE
Error enum and correct handling of no config

### DIFF
--- a/rex_xai/_utils.py
+++ b/rex_xai/_utils.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from enum import Enum
 from typing import Tuple, Union
 from numpy.typing import NDArray
 import torch as tt
@@ -6,6 +7,12 @@ import numpy as np
 from skimage.segmentation import mark_boundaries
 from rex_xai.logger import logger
 from rex_xai.box import Box
+
+Strategy = Enum("Strategy", ["Global", "Spatial", "Spotlight", "MultiSpotlight"])
+
+Queue = Enum("Queue", ["Area", "All", "Intersection", "DC"])
+
+ReXError = Enum("RexError", ["BadToml", "BadPath", "NoExplanation"])
 
 
 def add_boundaries(img: Union[NDArray, tt.Tensor], segs: NDArray) -> NDArray:

--- a/rex_xai/config.py
+++ b/rex_xai/config.py
@@ -6,7 +6,6 @@ import sys
 from typing import List, Optional
 from types import ModuleType
 import argparse
-from enum import Enum
 import os
 from os.path import exists, expanduser
 import importlib.util
@@ -17,12 +16,7 @@ import toml  # type: ignore
 from rex_xai.distributions import str2distribution
 from rex_xai.prediction import Prediction
 from rex_xai.distributions import Distribution
-
-CAUSAL = Enum("CAUSAL", ["Responsibility"])
-
-Strategy = Enum("Strategy", ["Global", "Spatial", "Spotlight", "MultiSpotlight"])
-
-Queue = Enum("Queue", ["Area", "All", "Intersection", "DC"])
+from rex_xai._utils import Strategy, Queue, ReXError
 
 
 class Args:
@@ -49,7 +43,7 @@ class Args:
         # onnx processing
         self.means = None
         self.stds = None
-        self.norm: Optional[float] = 255.0
+        self.norm: Optional[float] = None
         self.binary_threshold = None
         # verbosity
         self.verbosity = 0
@@ -75,7 +69,7 @@ class Args:
         # args for spatial strategy
         self.spatial_radius: int = 25
         self.spatial_eta: float = 0.2
-        self.no_expansions = 50
+        self.no_expansions = 4
         # spotlight args
         self.spotlights: int = 10
         self.spotlight_size: int = 20
@@ -117,7 +111,6 @@ class CausalArgs(Args):
     def __init__(self) -> None:
         super().__init__()
         self.config_location = None
-        self.type = CAUSAL
         self.tree_depth: int = 10
         self.search_limit: Optional[int] = None
         self.mask_value = 0
@@ -130,14 +123,12 @@ class CausalArgs(Args):
         self.distribution_args: Optional[List] = None
         self.blend = 0.0
         self.weighted: bool = False
-        self.iters = 20
+        self.iters = 30
         self.concentrate = False
+        self.min_confidence = 0.0
         # queue management
         self.queue_len = 1
         self.queue_style = Queue.Area
-
-        if self.min_box_size is not None:
-            self.chunk_size = self.min_box_size
 
     def __repr__(self) -> str:
         return (
@@ -158,12 +149,17 @@ class CausalArgs(Args):
 
 def get_config_file(path):
     """parses toml file into dictionary"""
+    if path is None:
+        return None
+    if not os.path.isfile(path):
+        return ReXError.BadPath
     try:
         file_args = toml.load(path)
         return file_args
     except Exception as e:
-        print(f"unable to read {path}: {e}")
-        exit(-1)
+        print("The following error has been found while parsing your config file:")
+        print(e)
+        return ReXError.BadToml
 
 
 def cmdargs():
@@ -182,6 +178,14 @@ def cmdargs():
         const="show",
         help="show minimal explanation, optionally saved to <OUTPUT>. Requires a PIL compatible file extension",
     )
+
+    parser.add_argument(
+        "--array",
+        nargs="?",
+        const="default",
+        help="save the boolean mask as a numpy array to <ARRAY>.",
+    )
+
     parser.add_argument("-c", "--config", type=str, help="config file to use for rex")
 
     parser.add_argument(
@@ -214,14 +218,22 @@ def cmdargs():
         help="heatmap plot, optionally saved to <HEATMAP>",
     )
 
+    parser.add_argument(
+        "--multi",
+        nargs="?",
+        const=0,
+        help="multiple explanations, with optional number <x> of floodlights, defaults to value in rex.toml, or 10 if undefined",
+    )
+
     parser.add_argument("--model", type=str, help="model, must be onnx format")
 
     parser.add_argument(
         "--strategy",
         "-s",
         type=str,
-        help="explanation strategy, one of < multi | spatial | linear | spotlight >",
+        help="explanation strategy, one of < spatial | global >",
     )
+
     parser.add_argument(
         "--database",
         "-db",
@@ -264,14 +276,12 @@ def cmdargs():
 
 def match_strategy(cmd_args):
     """gets explanation extraction strategy"""
-    if cmd_args.strategy == "multi":
+    if cmd_args.multi is not None or cmd_args.strategy == "multi":
         return Strategy.MultiSpotlight
     if cmd_args.strategy == "linear" or cmd_args.strategy == "global":
         return Strategy.Global
-    if cmd_args.strategy == "spotlight":
-        return Strategy.Spotlight
     if cmd_args.strategy == "spatial":
-        pass
+        return Strategy.Spatial
     return Strategy.Spatial
 
 
@@ -292,13 +302,14 @@ def get_objective_function(multi_dict):
         f = multi_dict["obj_function"]
         if f == "mean":
             return np.mean
-        if f == "max":
+        elif f == "max":
             return np.max
-        if f == "min":
+        elif f == "min":
             return np.min
+        elif f == "none":
+            return "none"
     except KeyError:
-        pass
-    return np.mean
+        return "none"
 
 
 def shared_args(cmd_args, args: CausalArgs):
@@ -348,124 +359,133 @@ def get_all_args(path=None):
 
     try:
         config_file_args = get_config_file(path)
-
         if config_file_args is None:
-            return args
+            print(
+                "ReX could not find a rex.toml, so running with defaults. This might not produce the effect you want..."
+            )
+        if config_file_args == ReXError.BadPath:
+            print(
+                f"The path you supplied for your config <{path}> is not correct. Have another look."
+            )
+            exit(-1)
+        if config_file_args == ReXError.BadToml:
+            exit(-1)
 
-        causal_dict = config_file_args["causal"]
-        if "tree_depth" in causal_dict:
-            args.tree_depth = causal_dict["tree_depth"]
-        if "search_limit" in causal_dict:
-            args.search_limit = causal_dict["search_limit"]
-        if "weighted" in causal_dict:
-            args.weighted = causal_dict["weighted"]
-        if "queue_len" in causal_dict:
-            ql = causal_dict["queue_len"]
-            if ql != "all":
-                args.queue_len = causal_dict["queue_len"]
-        if "queue_style" in causal_dict:
-            args.queue_style = match_queue_style(causal_dict["queue_style"])
-        if "iters" in causal_dict:
-            args.iters = causal_dict["iters"]
-        if "min_box_size" in causal_dict:
-            args.min_box_size = causal_dict["min_box_size"]
-        if "confidence_filter" in causal_dict:
-            args.confidence_filter = causal_dict["confidence_filter"]
-        if "segmentation" in causal_dict:
-            args.segmentation = causal_dict["segmentation"]
-        if "concentrate" in causal_dict:
-            args.concentrate = causal_dict["concentrate"]
+        if config_file_args is not None:
+            causal_dict = config_file_args["causal"]
+            if "tree_depth" in causal_dict:
+                args.tree_depth = causal_dict["tree_depth"]
+            if "search_limit" in causal_dict:
+                args.search_limit = causal_dict["search_limit"]
+            if "weighted" in causal_dict:
+                args.weighted = causal_dict["weighted"]
+            if "queue_len" in causal_dict:
+                ql = causal_dict["queue_len"]
+                if ql != "all":
+                    args.queue_len = causal_dict["queue_len"]
+            if "queue_style" in causal_dict:
+                args.queue_style = match_queue_style(causal_dict["queue_style"])
+            if "iters" in causal_dict:
+                args.iters = causal_dict["iters"]
+            if "min_box_size" in causal_dict:
+                args.min_box_size = causal_dict["min_box_size"]
+            if "confidence_filter" in causal_dict:
+                args.confidence_filter = causal_dict["confidence_filter"]
+            if "segmentation" in causal_dict:
+                args.segmentation = causal_dict["segmentation"]
+            if "concentrate" in causal_dict:
+                args.concentrate = causal_dict["concentrate"]
 
-        dist = causal_dict["distribution"]
-        d = dist["distribution"]
-        args.distribution = str2distribution(d)
-        if "dist_args" in dist:
-            args.distribution_args = dist["dist_args"]
-        if "blend" in dist:
-            b = dist["blend"]
-            if b < 0.0 or b > 1.0:
-                print("impossible blend value")
-                sys.exit(-1)
-            args.blend = dist["blend"]
+            dist = causal_dict["distribution"]
+            d = dist["distribution"]
+            args.distribution = str2distribution(d)
+            if "dist_args" in dist:
+                args.distribution_args = dist["dist_args"]
+            if "blend" in dist:
+                b = dist["blend"]
+                if b < 0.0 or b > 1.0:
+                    print("impossible blend value")
+                    sys.exit(-1)
+                args.blend = dist["blend"]
 
-        rex_dict = config_file_args["rex"]
-        if "mask_value" in rex_dict:
-            args.mask_value = rex_dict["mask_value"]
-        if "seed" in rex_dict:
-            args.seed = rex_dict["seed"]
-        if "gpu" in rex_dict:
-            args.gpu = rex_dict["gpu"]
-        if "batch_size" in rex_dict:
-            args.batch = rex_dict["batch_size"]
+            rex_dict = config_file_args["rex"]
+            if "mask_value" in rex_dict:
+                args.mask_value = rex_dict["mask_value"]
+            if "seed" in rex_dict:
+                args.seed = rex_dict["seed"]
+            if "gpu" in rex_dict:
+                args.gpu = rex_dict["gpu"]
+            if "batch_size" in rex_dict:
+                args.batch = rex_dict["batch_size"]
 
-        if "onnx" in rex_dict:
-            onnx = rex_dict["onnx"]
-            if "means" in onnx:
-                args.means = onnx["means"]
-            if "stds" in onnx:
-                args.stds = onnx["stds"]
-            if "binary_threshold" in onnx:
-                args.binary_threshold = onnx["binary_threshold"]
-            if "norm" in onnx:
-                args.norm = onnx["norm"]
+            if "onnx" in rex_dict:
+                onnx = rex_dict["onnx"]
+                if "means" in onnx:
+                    args.means = onnx["means"]
+                if "stds" in onnx:
+                    args.stds = onnx["stds"]
+                if "binary_threshold" in onnx:
+                    args.binary_threshold = onnx["binary_threshold"]
+                if "norm" in onnx:
+                    args.norm = onnx["norm"]
 
-        if "visual" in rex_dict:
-            if "info" in rex_dict["visual"]:
-                args.info = rex_dict["visual"]["info"]
-            if "colour" in rex_dict["visual"]:
-                args.colour = rex_dict["visual"]["colour"]
-            if "color" in rex_dict["visual"]:
-                args.colour = rex_dict["visual"]["color"]
-            if "alpha" in rex_dict["visual"]:
-                args.alpha = rex_dict["visual"]["alpha"]
-            if "raw" in rex_dict["visual"]:
-                args.raw = rex_dict["visual"]["raw"]
-            if "resize" in rex_dict["visual"]:
-                args.resize = rex_dict["visual"]["resize"]
-            if "progress_bar" in rex_dict["visual"]:
-                args.progress = rex_dict["visual"]["progress_bar"]
-            if "grid" in rex_dict["visual"]:
-                args.grid = rex_dict["visual"]["grid"]
-            if "mark_segments" in rex_dict["visual"]:
-                args.mark_segments = rex_dict["visual"]["mark_segments"]
-            if "heatmap" in rex_dict["visual"]:
-                args.heatmap_colours = rex_dict["visual"]["heatmap"]
+            if "visual" in rex_dict:
+                if "info" in rex_dict["visual"]:
+                    args.info = rex_dict["visual"]["info"]
+                if "colour" in rex_dict["visual"]:
+                    args.colour = rex_dict["visual"]["colour"]
+                if "color" in rex_dict["visual"]:
+                    args.colour = rex_dict["visual"]["color"]
+                if "alpha" in rex_dict["visual"]:
+                    args.alpha = rex_dict["visual"]["alpha"]
+                if "raw" in rex_dict["visual"]:
+                    args.raw = rex_dict["visual"]["raw"]
+                if "resize" in rex_dict["visual"]:
+                    args.resize = rex_dict["visual"]["resize"]
+                if "progress_bar" in rex_dict["visual"]:
+                    args.progress = rex_dict["visual"]["progress_bar"]
+                if "grid" in rex_dict["visual"]:
+                    args.grid = rex_dict["visual"]["grid"]
+                if "mark_segments" in rex_dict["visual"]:
+                    args.mark_segments = rex_dict["visual"]["mark_segments"]
+                if "heatmap" in rex_dict["visual"]:
+                    args.heatmap_colours = rex_dict["visual"]["heatmap"]
 
-        explain_dict = config_file_args["explanation"]
-        if "chunk" in explain_dict:
-            args.chunk_size = explain_dict["chunk"]
+            explain_dict = config_file_args["explanation"]
+            if "chunk" in explain_dict:
+                args.chunk_size = explain_dict["chunk"]
 
-        # spatial args
-        spatial_dict = explain_dict["spatial"]
-        if "initial_radius" in spatial_dict:
-            args.spatial_radius = spatial_dict["initial_radius"]
-        if "radius_eta" in spatial_dict:
-            args.spatial_eta = spatial_dict["radius_eta"]
-        if "no_expansions" in spatial_dict:
-            args.no_expansions = spatial_dict["no_expansions"]
+            # spatial args
+            spatial_dict = explain_dict["spatial"]
+            if "initial_radius" in spatial_dict:
+                args.spatial_radius = spatial_dict["initial_radius"]
+            if "radius_eta" in spatial_dict:
+                args.spatial_eta = spatial_dict["radius_eta"]
+            if "no_expansions" in spatial_dict:
+                args.no_expansions = spatial_dict["no_expansions"]
 
-        multi_dict = explain_dict["multi"]
-        if "spotlights" in multi_dict:
-            args.spotlights = multi_dict["spotlights"]
-        if "spotlight_size" in multi_dict:
-            args.spotlight_size = multi_dict["spotlight_size"]
-        if "spotlight_eta" in multi_dict:
-            args.spotlight_eta = multi_dict["spotlight_eta"]
-        if "spotlight_step" in multi_dict:
-            args.spotlight_step = multi_dict["spotlight_step"]
-        args.spotlight_objective_function = get_objective_function(multi_dict)  # type: ignore
+            multi_dict = explain_dict["multi"]
+            if "spotlights" in multi_dict:
+                args.spotlights = multi_dict["spotlights"]
+            if "spotlight_size" in multi_dict:
+                args.spotlight_size = multi_dict["spotlight_size"]
+            if "spotlight_eta" in multi_dict:
+                args.spotlight_eta = multi_dict["spotlight_eta"]
+            if "spotlight_step" in multi_dict:
+                args.spotlight_step = multi_dict["spotlight_step"]
+            args.spotlight_objective_function = get_objective_function(multi_dict)  # type: ignore
 
-        eval_dict = explain_dict["evaluation"]
-        if "insertion_step" in eval_dict:
-            args.insertion_step = eval_dict["insertion_step"]
+            if cmd_args.multi is not None:
+                if int(cmd_args.multi) > 0:
+                    args.spotlights = int(cmd_args.multi)
 
-    except KeyError as e:
-        print(f"key error {e} in {path}, so reverting to default args")
+            eval_dict = explain_dict["evaluation"]
+            if "insertion_step" in eval_dict:
+                args.insertion_step = eval_dict["insertion_step"]
 
-    except TypeError:
-        print(
-            "could not find a rex.toml, so running with defaults. This might not produce the effect you want..."
-        )
+    except Exception as e:
+        print(f"The following very unexpected error occurred: {e}")
+        exit(-1)
 
     if cmd_args.script is not None:
         try:


### PR DESCRIPTION
- Added an enum to represent errors and certain behaviour types (to avoid magic numbers). 

- There was an error introduced in 11d476c3bcdf5465835bd4a7ead7c80ec21cc1d7 so that ReX quit if no config file was present rather than reverting to defaults.