### PR TITLE
Add interactive "composite" style plotting for MultiExplanation

### DIFF
--- a/rex_xai/multi_explanation.py
+++ b/rex_xai/multi_explanation.py
@@ -32,9 +32,9 @@ class MultiExplanation(Explanation):
         elif multi_style == "composite":
             logger.info("using composite style to save explanations")
             if clauses is None:
-                clauses = range(0, len(self.explanations))
+                clause = range(0, len(self.explanations))
                 save_multi_explanation(
-                    self.explanations, self.data, self.args, clauses=clauses, path=path
+                    self.explanations, self.data, self.args, clause=clause, path=path
                 )
             else:
                 for clause in clauses:
@@ -44,7 +44,7 @@ class MultiExplanation(Explanation):
                         self.explanations,
                         self.data,
                         self.args,
-                        clauses=clause,
+                        clause=clause,
                         path=new_name,
                     )
 

--- a/rex_xai/multi_explanation.py
+++ b/rex_xai/multi_explanation.py
@@ -48,13 +48,37 @@ class MultiExplanation(Explanation):
                         path=new_name,
                     )
 
-    def show(self, path=None):
+    def show(self, path=None, multi_style=None, clauses=None):
+        if multi_style is None:
+            multi_style = self.args.multi_style
         outs = []
-        for i, mask in enumerate(self.explanations):
-            out = save_image(mask,self.data, self.args, path=None)
-            outs.append(out)
-        
-        plot_image_grid(outs)
+        if multi_style == "separate":
+            for i, mask in enumerate(self.explanations):
+                out = save_image(mask,self.data, self.args, path=None)
+                outs.append(out)
+    
+        elif multi_style == "composite":
+            if clauses is None:
+                clause = tuple([i for i in range(len(self.explanations))])
+                out = save_multi_explanation(
+                    self.explanations, self.data, self.args, clause=clause, path=None
+                )
+                outs.append(out)
+            else:
+                for clause in clauses:
+                    out = save_multi_explanation(
+                        self.explanations,
+                        self.data,
+                        self.args,
+                        clause=clause,
+                        path=None,
+                    )
+                    outs.append(out)
+ 
+        if len(outs) > 1:
+            plot_image_grid(outs)
+        else:
+            return outs[0]
 
     def extract(self, method=None):
         target_map = self.maps.get(self.data.target.classification)  # type: ignore

--- a/rex_xai/visualisation.py
+++ b/rex_xai/visualisation.py
@@ -319,11 +319,49 @@ def __transpose_mask(explanation, mode, transposed):
     return mask
 
 
-def save_multi_explanation(
-    explanations, data, args: CausalArgs, clauses=None, path=None
-):
+def generate_colours(n, colourmap):
+    """
+    Generate n evenly spaced RGB colours from a matplotlib colourmap.
+    """
+    space = np.linspace(0, 1, n)
+    colour_space = mpl.colormaps[colourmap].resampled(n)
+    # colour space returns colours in RGBA space, so we drop the A at the end
+    rgb_colours = [colour_space(i)[:-1] for i in space]
+    return rgb_colours
+
+
+def make_composite_mask(explanations):
+    """
+    Creates a composite mask from a list of masks.
+    """
     composite_mask = None
-    img = None
+    for explanation in explanations:
+        if composite_mask is None:
+            composite_mask = explanation
+        else:
+            composite_mask = np.where(explanation, 1, composite_mask)
+
+    return composite_mask
+
+
+def apply_boundaries_to_image(image, explanations, colours):
+    """
+    Draws the boundaries of the explanations on the image, using the provided colours.
+    """
+    for i in range(len(explanations)):
+        explanation = explanations[i]
+
+        if explanation.shape[0] == 3:
+            explanation = explanation[0, :, :]
+        else:
+            explanation = explanation[:, :, 0]  # type: ignore
+
+        image = add_boundaries(image, explanation, colour=colours[i])
+    
+    return image
+
+
+def get_img_as_array(data):
     if data.mode == "RGB" or data.mode == "L":
         if data.mode == "L":
             img = data.input.convert("RGB").resize(
@@ -332,35 +370,29 @@ def save_multi_explanation(
         else:
             img = data.input.resize((data.model_height, data.model_width))
     else:
-        logger.warn("we do not yet handle multiple explanations for non-images")
+        logger.warning("we do not yet handle multiple explanations for non-images")
         raise NotImplementedError
+    
+    return np.array(img)
 
+
+def save_multi_explanation(
+    explanations, data, args: CausalArgs, clause=None, path=None
+):
+    
+    img = get_img_as_array(data)
     if img is not None:
-        img = np.array(img)
+        rgb_colours = generate_colours(args.spotlights, args.heatmap_colours)
 
-        space = np.linspace(0, 1, args.spotlights)
-        colour_space = mpl.colormaps[args.heatmap_colours].resampled(args.spotlights)
-        # colour space returns colours in RGBA space, so we drop the A at the end
-        rgb_colours = [colour_space(i)[:-1] for i in space]
+        if clause is not None:
+            # subset explanations and transpose if necessary
+            explanations_subset = [explanations[c] for c in clause]
+            explanations_subset = [__transpose_mask(explanation, data.mode, data.transposed) for explanation in explanations_subset]
+            composite_mask = make_composite_mask(explanations_subset)
 
-        if clauses is not None:
-            for c in clauses:
-                explanation = explanations[c]
-                explanation = __transpose_mask(explanation, data.mode, data.transposed)
-                if explanation is not None:
-                    if composite_mask is None:
-                        composite_mask = explanation
-                    else:
-                        composite_mask = np.where(explanation, 1, composite_mask)
-
-                assert explanation is not None
-                if explanation.shape[0] == 3:
-                    explanation = explanation[0, :, :]
-                else:
-                    explanation = explanation[:, :, 0]  # type: ignore
-
-                img = add_boundaries(img, explanation, colour=rgb_colours[c])
-
+            colours_subset = [rgb_colours[c] for c in clause]
+            img = apply_boundaries_to_image(img, explanations_subset, colours_subset)
+            
             if composite_mask is not None and path is not None:
                 cover = np.where(composite_mask, img, args.colour)
                 cover = Image.fromarray(cover, data.mode)


### PR DESCRIPTION
I split the code in `save_multi_explanation` into a few smaller functions, as I thought I might need to write a completely new function re-using these in order to get the interactive composite plotting to work - but in the end I was able to adapt `save_multi_explanation`!

I think the new `get_img_as_array` function could probably be reused in other plotting functions like `save_image` and `heatmap_plot`, but haven't implemented this yet. Would it be more useful for reuse if it returned an `Image` rather an a `np.array`?