### PR TITLE
feat: added conversion of RGBA to RGB images

### DIFF
--- a/rex_xai/explanation.py
+++ b/rex_xai/explanation.py
@@ -59,8 +59,12 @@ def try_preprocess(args: CausalArgs, model_shape: Tuple[int], device: tt.device)
         except AttributeError:
             pass
 
-        # if not args.processed:
-        data = Data(Image.open(args.path), model_shape, device)
+        img = Image.open(args.path)
+        if img.mode == "RGBA":
+            logger.warning("RGBA input image provided, converting to RGB")
+            img = img.convert("RGB")
+        
+        data = Data(img, model_shape, device)
         # data = Data(Image.open(args.path).convert("RGB"), model_shape, device)
         data.generic_image_preprocess(means=args.means, stds=args.stds, norm=args.norm)
 

--- a/tests/unit_tests/preprocessing_test.py
+++ b/tests/unit_tests/preprocessing_test.py
@@ -24,3 +24,15 @@ def test_validate_args(args):
     args.path = None  #  type: ignore
     with pytest.raises(FileNotFoundError):
         validate_args(args)
+
+
+def test_preprocess_rgba(args, model_shape, prediction_func, cpu_device, caplog):
+    args.path = "assets/rex_logo.png"
+    data = try_preprocess(args, model_shape, device=cpu_device)
+    predict_target(data, prediction_func)
+    
+    assert caplog.records[0].msg == "RGBA input image provided, converting to RGB"
+    assert data.mode == "RGB"
+    assert data.input.mode == "RGB"
+    assert data.data.shape[1] == 3 # batch, channels, height, width
+

--- a/tests/unit_tests/preprocessing_test.py
+++ b/tests/unit_tests/preprocessing_test.py
@@ -1,4 +1,5 @@
 import pytest
+from rex_xai.config import validate_args
 from rex_xai.explanation import (
     predict_target,
     try_preprocess,
@@ -19,7 +20,6 @@ def test_predict_target(data, prediction_func):
     assert target.confidence == pytest.approx(0.253237, abs=2.5e-6)
 
 
-
 def test_validate_args(args):
     args.path = None  #  type: ignore
     with pytest.raises(FileNotFoundError):
@@ -34,4 +34,5 @@ def test_preprocess_rgba(args, model_shape, prediction_func, cpu_device, caplog)
     assert caplog.records[0].msg == "RGBA input image provided, converting to RGB"
     assert data.mode == "RGB"
     assert data.input.mode == "RGB"
+    assert data.data is not None
     assert data.data.shape[1] == 3 # batch, channels, height, width


### PR DESCRIPTION
Resolves #13.

This directly converts the input image to RGB, and does not retain the original RGBA image for later plotting purposes. IMO this should be fine, since the plotting will then better reflect the image that was analysed.