### PR TITLE
Simplify input to update_database function; add tests

### DIFF
--- a/rex_xai/database.py
+++ b/rex_xai/database.py
@@ -49,7 +49,7 @@ def db_to_pandas(db, dtype=np.float32, table="rex"):
 def update_database(
     db,
     explanation: Explanation,
-    time_taken,
+    time_taken=None,
     multi=False,
 ):
     target_map = explanation.target_map

--- a/rex_xai/database.py
+++ b/rex_xai/database.py
@@ -15,7 +15,7 @@ from rex_xai.logger import logger
 from rex_xai.config import CausalArgs, Strategy
 from rex_xai.prediction import Prediction
 from rex_xai.extraction import Explanation
-
+from rex_xai.multi_explanation import MultiExplanation
 
 def _dataframe(db, table):
     return pd.read_sql_table(table, f"sqlite:///{db}")
@@ -48,13 +48,8 @@ def db_to_pandas(db, dtype=np.float32, table="rex"):
 
 def update_database(
     db,
-    target: Prediction,
     explanation: Explanation,
     time_taken,
-    total_passing,
-    total_failing,
-    max_depth_reached,
-    avg_box_size,
     multi=False,
 ):
     target_map = explanation.target_map
@@ -62,12 +57,16 @@ def update_database(
     if isinstance(target_map, tt.Tensor):
         target_map = target_map.detach().cpu().numpy()
 
+    target = explanation.data.target
+    if target is None:
+        logger.warning("unable to update database as target is None")
+        return
     classification = int(target.classification)  # type: ignore
 
     if not multi:
         final_mask = explanation.final_mask
         if explanation.final_mask is None:
-            logger.warn("unable to update database as explanation is empty")
+            logger.warning("unable to update database as explanation is empty")
             return
         if isinstance(final_mask, tt.Tensor):
             final_mask = final_mask.detach().cpu().numpy()
@@ -80,13 +79,16 @@ def update_database(
             target_map,
             final_mask,
             time_taken,
-            total_passing,
-            total_failing,
-            max_depth_reached,
-            avg_box_size,
+            explanation.run_stats["total_passing"],
+            explanation.run_stats["total_failing"],
+            explanation.run_stats["max_depth_reached"],
+            explanation.run_stats["avg_box_size"],
         )
 
     else:
+        if explanation is not MultiExplanation:
+            logger.warning("unable to update database, multi=True is only valid for MultiExplanation objects")
+            return
         for c, final_mask in enumerate(explanation.explanations):
             if isinstance(final_mask, tt.Tensor):
                 final_mask = final_mask.detach().cpu().numpy()
@@ -98,10 +100,10 @@ def update_database(
                 target_map,
                 final_mask,
                 time_taken,
-                total_passing,
-                total_failing,
-                max_depth_reached,
-                avg_box_size,
+                explanation.run_stats["total_passing"],
+                explanation.run_stats["total_failing"],
+                explanation.run_stats["max_depth_reached"],
+                explanation.run_stats["avg_box_size"],
                 multi=multi,
                 multi_no=c,
             )

--- a/rex_xai/database.py
+++ b/rex_xai/database.py
@@ -13,7 +13,6 @@ import numpy as np
 
 from rex_xai.logger import logger
 from rex_xai.config import CausalArgs, Strategy
-from rex_xai.prediction import Prediction
 from rex_xai.extraction import Explanation
 from rex_xai.multi_explanation import MultiExplanation
 

--- a/rex_xai/explanation.py
+++ b/rex_xai/explanation.py
@@ -370,26 +370,16 @@ def _explanation(
             logger.info("writing multiple explanations to database")
             update_database(
                 db,
-                data.target,
                 exp,
                 time_taken,
-                exp.run_stats["total_passing"],
-                exp.run_stats["total_failing"],
-                exp.run_stats["max_depth_reached"],
-                exp.run_stats["avg_box_size"],
                 multi=True,
             )
         else:
             logger.info("writing to database")
             update_database(
                 db,
-                data.target,  # type: ignore
                 exp,
                 time_taken,
-                exp.run_stats["total_passing"],
-                exp.run_stats["total_failing"],
-                exp.run_stats["max_depth_reached"],
-                exp.run_stats["avg_box_size"],
             )
 
     return exp

--- a/tests/unit_tests/database_test.py
+++ b/tests/unit_tests/database_test.py
@@ -39,3 +39,10 @@ def test_read_db(exp_extracted, tmp_path):
     update_database(db, exp_extracted)
     df = db_to_pandas(p)
     assert df.shape == (1, 29)
+
+
+def test_no_multi(exp_extracted, caplog):
+    update_database(db, exp_extracted, multi=True)
+    assert (
+        caplog.records[0].message == "unable to update database, multi=True is only valid for MultiExplanation objects"
+    )

--- a/tests/unit_tests/database_test.py
+++ b/tests/unit_tests/database_test.py
@@ -1,0 +1,41 @@
+import os
+
+import pytest
+from rex_xai.database import db_to_pandas, initialise_rex_db, update_database
+
+
+@pytest.fixture
+def db(tmp_path):
+    p = tmp_path / "rex.db"
+    db = initialise_rex_db(p)
+    return db
+
+
+def test_update_database(exp_extracted, tmp_path):
+    p = tmp_path / "rex.db"
+    db = initialise_rex_db(p)
+    update_database(db, exp_extracted)
+    assert os.path.exists(p)
+    assert os.stat(p).st_size > 0
+
+
+def test_update_database_no_target(exp_extracted, db, caplog):
+    exp_extracted.data.target = None
+    update_database(db, exp_extracted)
+    assert caplog.records[0].message == "unable to update database as target is None"
+
+
+def test_update_database_no_exp(exp_extracted, db, caplog):
+    exp_extracted.final_mask = None
+    update_database(db, exp_extracted)
+    assert (
+        caplog.records[0].message == "unable to update database as explanation is empty"
+    )
+
+
+def test_read_db(exp_extracted, tmp_path):
+    p = tmp_path / "rex.db"
+    db = initialise_rex_db(p)
+    update_database(db, exp_extracted)
+    df = db_to_pandas(p)
+    assert df.shape == (1, 29)


### PR DESCRIPTION
I realised we can simplify the input to `update_database` a lot, since everything except `time_taken` is stored in the Explanation object. This will be particularly nice for interactive use!

I added some tests for writing to and reading from the database. I also added a couple of checks in `update_database` that should remove a couple of Pyright complaints.

Once #61 is merged, I can add tests for saving and reading of multi-explanations, too.