### PR TITLE
fix: fix undefined variable issue in version number check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,8 @@ jobs:
       run: |
         PYTHON_VERSION=`ReX --version`
         echo "PYTHON_VERSION=${PYTHON_VERSION}"
-        echo "GIT_VERSION=$GITHUB_REF_NAME" # NB that Github version should have a 'v' prefix
+        GIT_VERSION=$GITHUB_REF_NAME
+        echo "GIT_VERSION=${GIT_VERSION}" # NB that Github version should have a 'v' prefix
         if [ v$PYTHON_VERSION != $GIT_VERSION ]; then exit 1; fi
         echo "VERSION=${GIT_VERSION}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
         echo "PYTHON_VERSION=${PYTHON_VERSION}"
         GIT_VERSION=$GITHUB_REF_NAME
         echo "GIT_VERSION=${GIT_VERSION}" # NB that Github version should have a 'v' prefix
-        if [ v$PYTHON_VERSION != $GIT_VERSION ]; then exit 1; fi
+        if [ "v$PYTHON_VERSION" != "$GIT_VERSION" ]; then exit 1; fi
         echo "VERSION=${GIT_VERSION}" >> $GITHUB_OUTPUT
 
   pypi-publish:


### PR DESCRIPTION
There was a bash syntax error in the workflow caused by `$GIT_VERSION` being undefined; I tried to simplify [the workflow I was copying](https://github.com/SNEWS2/snewpy/blob/09d25cb72e20646cc3cb58727a7c7b5fa5ad2dc3/.github/workflows/publish.yml#L26) but missed some necessary updates. Since bash syntax errors don't return an error code, the workflow step looked like it was successful. 