### PR TITLE
Fix/explanation methods

### DIFF
--- a/rex_xai/explanation/explanation.py
+++ b/rex_xai/explanation/explanation.py
@@ -155,7 +155,7 @@ class Explanation:
                         return p.confidence
                 masks = []
 
-    def __generate_circle_coordinates(self, centre, radius: int):
+    def _generate_circle_coordinates(self, centre, radius: int):
         assert self.data.model_height is not None
         assert self.data.model_width is not None
         Y, X = tt.meshgrid(
@@ -174,13 +174,13 @@ class Explanation:
 
         return circle_mask
 
-    def __draw_circle(self, centre, start_radius=None):
+    def _draw_circle(self, centre, start_radius=None):
         if start_radius is None:
             start_radius = self.args.spatial_initial_radius
         mask = tt.zeros(
             self.data.model_shape[1:], dtype=tt.bool, device=self.data.device
         )
-        circle_mask = self.__generate_circle_coordinates(centre, start_radius)
+        circle_mask = self._generate_circle_coordinates(centre, start_radius)
         if self.data.model_order == "first":
             mask[:, circle_mask] = True
         else:
@@ -218,7 +218,7 @@ class Explanation:
         if centre is None:
             centre = tt.unravel_index(tt.argmax(map), map.shape)  # type: ignore
 
-        start_radius, circle, mask = self.__draw_circle(centre)
+        start_radius, circle, mask = self._draw_circle(centre)
 
         if self.args.spotlight_objective_function == "none":
             masked_responsibility = None
@@ -246,7 +246,7 @@ class Explanation:
                 conf = self._global(map=tt.where(circle, map, 0))  # type: ignore
                 return SpatialSearch.Found, masked_responsibility, conf
             start_radius = int(start_radius * (1 + self.args.spatial_radius_eta))
-            _, circle, _ = self.__draw_circle(centre, start_radius)
+            _, circle, _ = self._draw_circle(centre, start_radius)
             if self.data.model_order == "first":
                 mask[:, circle] = True
             else:

--- a/rex_xai/explanation/explanation.py
+++ b/rex_xai/explanation/explanation.py
@@ -87,15 +87,15 @@ class Explanation:
     def extract(self, method: Strategy):
         self.blank()
         if method == Strategy.Global:
-            self.__global()
+            self._global()
         if method == Strategy.Spatial:
             if self.data.mode == "spectral":
                 logger.warning(
                     "spatial search not yet implemented for spectral data, so defaulting to global search"
                 )
-                self.__global()
+                self._global()
             else:
-                _ = self.__spatial()
+                _ = self._spatial()
 
         if isinstance(self.final_mask, tt.Tensor):
             self.final_mask = self.final_mask.detach().cpu().numpy()
@@ -115,7 +115,7 @@ class Explanation:
                 mask, self.data.mode, self.data.model_order, coords
             )
 
-    def __global(self, map=None, wipe=False):
+    def _global(self, map=None, wipe=False):
         if map is None:
             map = self.target_map
         ranking = get_map_locations(map)
@@ -212,7 +212,7 @@ class Explanation:
         )
         return tt.mean(masked_responsibility).item()
 
-    def __spatial(self, centre=None, expansion_limit=None):
+    def _spatial(self, centre=None, expansion_limit=None):
         # we don't have a search location to start from, so we try to isolate one
         map = self.target_map
         if centre is None:
@@ -243,7 +243,7 @@ class Explanation:
                 and p.confidence
                 >= self.data.target.confidence * self.args.minimum_confidence_threshold  # type: ignore
             ):
-                conf = self.__global(map=tt.where(circle, map, 0))  # type: ignore
+                conf = self._global(map=tt.where(circle, map, 0))  # type: ignore
                 return SpatialSearch.Found, masked_responsibility, conf
             start_radius = int(start_radius * (1 + self.args.spatial_radius_eta))
             _, circle, _ = self.__draw_circle(centre, start_radius)

--- a/rex_xai/explanation/multi_explanation.py
+++ b/rex_xai/explanation/multi_explanation.py
@@ -123,7 +123,7 @@ class MultiExplanation(Explanation):
         self.blank()
         # we start with the global max explanation
         logger.info("spotlight number 1 (global max)")
-        conf = self._Explanation__global()  # type: ignore
+        conf = self._global() 
         if self.final_mask is not None:
             self.explanations.append(self.final_mask)
             self.explanation_confidences.append(conf)
@@ -251,7 +251,7 @@ class MultiExplanation(Explanation):
         else:
             centre = origin
 
-        ret, resp, conf = self._Explanation__spatial(  # type: ignore
+        ret, resp, conf = self._spatial(
             centre=centre, expansion_limit=self.args.no_expansions
         )
 
@@ -259,7 +259,7 @@ class MultiExplanation(Explanation):
         while ret == SpatialSearch.NotFound and steps < self.args.max_spotlight_budget:
             if self.args.spotlight_objective_function == "none":
                 centre = self.__random_location()
-                ret, resp, conf = self._Explanation__spatial(  # type: ignore
+                ret, resp, conf = self._spatial( 
                     centre=centre, expansion_limit=self.args.no_expansions
                 )
             else:
@@ -271,12 +271,12 @@ class MultiExplanation(Explanation):
                         self.data.model_width,
                         step=self.args.spotlight_step,
                     )
-                    ret, new_resp, conf = self._Explanation__spatial(  # type: ignore
+                    ret, new_resp, conf = self._spatial(  # type: ignore
                         centre=centre, expansion_limit=self.args.no_expansions
                     )
                     if ret == SpatialSearch.Found:
                         return conf
-                ret, resp, conf = self._Explanation__spatial(  # type: ignore
+                ret, resp, conf = self._spatial(  # type: ignore
                     centre=centre, expansion_limit=self.args.no_expansions
                 )
             steps += 1

--- a/rex_xai/explanation/multi_explanation.py
+++ b/rex_xai/explanation/multi_explanation.py
@@ -251,7 +251,7 @@ class MultiExplanation(Explanation):
         else:
             centre = origin
 
-        ret, resp, conf = self._spatial(
+        ret, resp, conf = self._spatial(  # type: ignore
             centre=centre, expansion_limit=self.args.no_expansions
         )
 
@@ -259,7 +259,7 @@ class MultiExplanation(Explanation):
         while ret == SpatialSearch.NotFound and steps < self.args.max_spotlight_budget:
             if self.args.spotlight_objective_function == "none":
                 centre = self.__random_location()
-                ret, resp, conf = self._spatial( 
+                ret, resp, conf = self._spatial(  # type: ignore
                     centre=centre, expansion_limit=self.args.no_expansions
                 )
             else:


### PR DESCRIPTION
Resolves #73 - however sadly this only fixes two Pyright complaints that were associated with using `_Explanation__global`.

Pyright still complains when `_spatial` is used, and I don't understand the relevance of the error it reports: 
```
 "None" is not iterable
  "__iter__" method not defined
```

(I would hold off on merging this until after #48 is merged, it's not urgent)