### PR TITLE
Add tests for processing of command line arguments

### DIFF
--- a/tests/unit_tests/cmd_args_test.py
+++ b/tests/unit_tests/cmd_args_test.py
@@ -1,4 +1,6 @@
 import pytest
+from types import ModuleType
+
 from rex_xai._utils import Strategy
 from rex_xai.config import CausalArgs, shared_args, cmdargs_parser, process_cmd_args
 
@@ -24,7 +26,7 @@ from rex_xai.config import CausalArgs, shared_args, cmdargs_parser, process_cmd_
 
 @pytest.fixture
 def non_default_cmd_args():
-    return ['filename.jpg',
+    args_list = ['filename.jpg',
         '--output', 'output_path.jpg',
         '--config', 'path/to/rex.toml',
         '--processed',
@@ -40,36 +42,35 @@ def non_default_cmd_args():
         '--analyze',
         '--mode', 'RGB',
     ]
+    parser = cmdargs_parser()
+    cmd_args = parser.parse_args(args_list)
+
+    return cmd_args
 
 
 def test_process_cmd_args(non_default_cmd_args):
     args = CausalArgs()
-    parser = cmdargs_parser()
-    cmd_args = parser.parse_args(non_default_cmd_args)
-    process_cmd_args(cmd_args, args)
+    process_cmd_args(non_default_cmd_args, args)
 
-    #assert args.script == cmd_args.script
-    assert args.path == cmd_args.filename
+    assert isinstance(args.script, ModuleType)
+    assert args.path == non_default_cmd_args.filename
     assert args.strategy == Strategy.MultiSpotlight
-    assert args.iters == int(cmd_args.iters)
+    assert args.iters == int(non_default_cmd_args.iters)
     assert args.analyze 
-    assert args.spotlights == int(cmd_args.multi)
+    assert args.spotlights == int(non_default_cmd_args.multi)
 
     
 def test_process_shared_args(non_default_cmd_args):
     args = CausalArgs()
-    parser = cmdargs_parser()
-    cmd_args = parser.parse_args(non_default_cmd_args)
-    shared_args(cmd_args, args)
+    shared_args(non_default_cmd_args, args)
 
-    
-    assert args.config_location == cmd_args.config
-    assert args.model == cmd_args.model
-    assert args.surface == cmd_args.surface
-    assert args.heatmap == cmd_args.heatmap
-    assert args.output == cmd_args.output
-    assert args.verbosity == cmd_args.verbose
-    assert args.db == cmd_args.database
-    assert args.mode == cmd_args.mode
-    assert args.processed == cmd_args.processed
+    assert args.config_location == non_default_cmd_args.config
+    assert args.model == non_default_cmd_args.model
+    assert args.surface == non_default_cmd_args.surface
+    assert args.heatmap == non_default_cmd_args.heatmap
+    assert args.output == non_default_cmd_args.output
+    assert args.verbosity == non_default_cmd_args.verbose
+    assert args.db == non_default_cmd_args.database
+    assert args.mode == non_default_cmd_args.mode
+    assert args.processed == non_default_cmd_args.processed
 

--- a/tests/unit_tests/cmd_args_test.py
+++ b/tests/unit_tests/cmd_args_test.py
@@ -1,8 +1,8 @@
 from types import ModuleType
 
 import pytest
-from rex_xai._utils import Strategy
-from rex_xai.config import CausalArgs, cmdargs_parser, process_cmd_args, shared_args
+from rex_xai.utils._utils import Strategy
+from rex_xai.input.config import CausalArgs, cmdargs_parser, process_cmd_args, shared_args
 
 
 @pytest.fixture

--- a/tests/unit_tests/cmd_args_test.py
+++ b/tests/unit_tests/cmd_args_test.py
@@ -1,46 +1,42 @@
-import pytest
 from types import ModuleType
 
+import pytest
 from rex_xai._utils import Strategy
-from rex_xai.config import CausalArgs, shared_args, cmdargs_parser, process_cmd_args
+from rex_xai.config import CausalArgs, cmdargs_parser, process_cmd_args, shared_args
 
-
-# filename (path)
-# output (path)
-# config (path)
-# processed (bool)
-# script (path)
-# verbose (int)
-# quiet (bool)
-# surface (path)
-# heatmap (path)
-# model (path)
-# strategy (multi | spatial | global | spotlight)
-# database (path)
-# multi (int)
 # contrastive (int)
-# iters (int)
-# analyze/analyse (bool)
-# mode (<tabular>, <spectral>, <RGB>, <voxel>, <audio>)
 # spectral (bool)
+
 
 @pytest.fixture
 def non_default_cmd_args():
-    args_list = ['filename.jpg',
-        '--output', 'output_path.jpg',
-        '--config', 'path/to/rex.toml',
-        '--processed',
-        '--script', 'tests/scripts/pytorch_resnet50.py',
-        '-vv',
-        '--surface', 'surface_path.jpg',
-        '--heatmap', 'heatmap_path.jpg',
-        '--model', 'path/to/model.onnx',
-        '--strategy', 'multi',
-        '--database', 'path/to/database.db',
-        '--multi', '5',
-        '--iters', '10',
-        '--analyze',
-        '--mode', 'RGB',
+    args_list = [
+        "filename.jpg",
+        "--output",
+        "output_path.jpg",
+        "--config",
+        "path/to/rex.toml",
+        "--processed",
+        "--script",
+        "tests/scripts/pytorch_resnet50.py",
+        "-vv",
+        "--surface",
+        "surface_path.jpg",
+        "--heatmap",
+        "heatmap_path.jpg",
+        "--model",
+        "path/to/model.onnx",
+        "--strategy",
+        "multi",
+        "--database",
+        "path/to/database.db",
+        "--multi",
+        "5",
+        "--iters",
+        "10",
+        "--analyze",
+        "--mode",
+        "RGB",
     ]
     parser = cmdargs_parser()
     cmd_args = parser.parse_args(args_list)
@@ -56,10 +52,10 @@ def test_process_cmd_args(non_default_cmd_args):
     assert args.path == non_default_cmd_args.filename
     assert args.strategy == Strategy.MultiSpotlight
     assert args.iters == int(non_default_cmd_args.iters)
-    assert args.analyze 
+    assert args.analyze
     assert args.spotlights == int(non_default_cmd_args.multi)
 
-    
+
 def test_process_shared_args(non_default_cmd_args):
     args = CausalArgs()
     shared_args(non_default_cmd_args, args)
@@ -74,3 +70,12 @@ def test_process_shared_args(non_default_cmd_args):
     assert args.mode == non_default_cmd_args.mode
     assert args.processed == non_default_cmd_args.processed
 
+
+def test_quiet_overrides_verbose():
+    cmd_args_list = ["filename.jpg", "-vv", "--quiet"]
+    parser = cmdargs_parser()
+    cmd_args = parser.parse_args(cmd_args_list)
+    args = CausalArgs()
+    shared_args(cmd_args, args)
+
+    assert args.verbosity == 0

--- a/tests/unit_tests/cmd_args_test.py
+++ b/tests/unit_tests/cmd_args_test.py
@@ -79,3 +79,14 @@ def test_quiet_overrides_verbose():
     shared_args(cmd_args, args)
 
     assert args.verbosity == 0
+
+
+def test_contrastive():
+    cmd_args_list = ["filename.jpg", "--contrastive", "5"]
+    parser = cmdargs_parser()
+    cmd_args = parser.parse_args(cmd_args_list)
+    args = CausalArgs()
+    process_cmd_args(cmd_args, args)
+    
+    assert args.strategy == Strategy.Contrastive
+    assert args.spotlights == int(cmd_args.contrastive)

--- a/tests/unit_tests/cmd_args_test.py
+++ b/tests/unit_tests/cmd_args_test.py
@@ -4,9 +4,6 @@ import pytest
 from rex_xai._utils import Strategy
 from rex_xai.config import CausalArgs, cmdargs_parser, process_cmd_args, shared_args
 
-# contrastive (int)
-# spectral (bool)
-
 
 @pytest.fixture
 def non_default_cmd_args():
@@ -87,6 +84,16 @@ def test_contrastive():
     cmd_args = parser.parse_args(cmd_args_list)
     args = CausalArgs()
     process_cmd_args(cmd_args, args)
-    
+
     assert args.strategy == Strategy.Contrastive
     assert args.spotlights == int(cmd_args.contrastive)
+
+
+def test_spectral():
+    cmd_args_list = ["filename.jpg", "--spectral"]
+    parser = cmdargs_parser()
+    cmd_args = parser.parse_args(cmd_args_list)
+    args = CausalArgs()
+    shared_args(cmd_args, args)
+
+    assert args.mode == "spectral"

--- a/tests/unit_tests/cmd_args_test.py
+++ b/tests/unit_tests/cmd_args_test.py
@@ -1,0 +1,75 @@
+import pytest
+from rex_xai._utils import Strategy
+from rex_xai.config import CausalArgs, shared_args, cmdargs_parser, process_cmd_args
+
+
+# filename (path)
+# output (path)
+# config (path)
+# processed (bool)
+# script (path)
+# verbose (int)
+# quiet (bool)
+# surface (path)
+# heatmap (path)
+# model (path)
+# strategy (multi | spatial | global | spotlight)
+# database (path)
+# multi (int)
+# contrastive (int)
+# iters (int)
+# analyze/analyse (bool)
+# mode (<tabular>, <spectral>, <RGB>, <voxel>, <audio>)
+# spectral (bool)
+
+@pytest.fixture
+def non_default_cmd_args():
+    return ['filename.jpg',
+        '--output', 'output_path.jpg',
+        '--config', 'path/to/rex.toml',
+        '--processed',
+        '--script', 'tests/scripts/pytorch_resnet50.py',
+        '-vv',
+        '--surface', 'surface_path.jpg',
+        '--heatmap', 'heatmap_path.jpg',
+        '--model', 'path/to/model.onnx',
+        '--strategy', 'multi',
+        '--database', 'path/to/database.db',
+        '--multi', '5',
+        '--iters', '10',
+        '--analyze',
+        '--mode', 'RGB',
+    ]
+
+
+def test_process_cmd_args(non_default_cmd_args):
+    args = CausalArgs()
+    parser = cmdargs_parser()
+    cmd_args = parser.parse_args(non_default_cmd_args)
+    process_cmd_args(cmd_args, args)
+
+    #assert args.script == cmd_args.script
+    assert args.path == cmd_args.filename
+    assert args.strategy == Strategy.MultiSpotlight
+    assert args.iters == int(cmd_args.iters)
+    assert args.analyze 
+    assert args.spotlights == int(cmd_args.multi)
+
+    
+def test_process_shared_args(non_default_cmd_args):
+    args = CausalArgs()
+    parser = cmdargs_parser()
+    cmd_args = parser.parse_args(non_default_cmd_args)
+    shared_args(cmd_args, args)
+
+    
+    assert args.config_location == cmd_args.config
+    assert args.model == cmd_args.model
+    assert args.surface == cmd_args.surface
+    assert args.heatmap == cmd_args.heatmap
+    assert args.output == cmd_args.output
+    assert args.verbosity == cmd_args.verbose
+    assert args.db == cmd_args.database
+    assert args.mode == cmd_args.mode
+    assert args.processed == cmd_args.processed
+


### PR DESCRIPTION
- tests that command line arguments correctly override default values in CausalArgs object
- tests that command line options with special handling, such as `--quiet` and `--spectral` are appropriately handled