### PR TITLE
Fix: Fixing dependency versions in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 
 dependencies = [
-    "numpy==1.26.4",
+    "numpy>=2.1.0",
     "scipy>=1.10",
     "imutils>=0.5.4",
     "toml>=0.10",


### PR DESCRIPTION
## Summary
 - Fixes numpy hard dependency of `numpy 1.26.4` to `>= 2.1.0` in `pyproject.toml`

## Reason
- Python >= 3.13 (which is recommended in the README for creating new environment) does not have a prebuilt wheel for `numpy 1.26.4`, leading to source build fails. `numpy 2.1.0` is the earliest version with prebuilt wheel for Python 3.13.